### PR TITLE
[gh-pr-manager] Add branch selector after repo selection

### DIFF
--- a/tests/test_app_smoke.py
+++ b/tests/test_app_smoke.py
@@ -6,7 +6,7 @@ import subprocess
 from pathlib import Path
 
 from gh_pr_manager import main
-from gh_pr_manager.main import PRManagerApp, BranchList
+from gh_pr_manager.main import PRManagerApp, BranchSelector
 
 @pytest.mark.asyncio
 async def test_app_runs():
@@ -35,4 +35,4 @@ async def test_select_repo_shows_branches(tmp_path, monkeypatch):
         await pilot.click("#continue")
         await pilot.click("#confirm")
         await pilot.pause()
-        assert pilot.app.query_one(BranchList)
+        assert pilot.app.query_one(BranchSelector)


### PR DESCRIPTION
## Summary
- list local branches when a repository is selected
- display them with a new `BranchSelector` widget
- update tests for `BranchSelector`

## Testing
- `pytest -q`
- `PYTHONPATH=src python -m gh_pr_manager.main & sleep 2; kill $!`

------
https://chatgpt.com/codex/tasks/task_b_684d897fb840833090b132e79c3e4120