### PR TITLE
[gh-pr-manager] Add repository management view

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -11,7 +11,7 @@ This document tracks the tasks, milestones, and ongoing progress for the develop
 - [x] Repository selection UI from pre-configured list
 - [x] Branch listing UI after repo selection
 - [x] Branch actions: delete, PR+merge+delete flow
-- [ ] Repo list editing flow (add/remove repos)
+- [x] Repo list editing flow (add/remove repos)
 - [ ] Error handling and user feedback for all flows
   - [ ] Handle missing/invalid repositories
   - [ ] Handle gh CLI errors
@@ -37,6 +37,7 @@ This document tracks the tasks, milestones, and ongoing progress for the develop
 ## Progress Log
 
 - **2025-06-14:** Project initialized, test infra working, AGENTS.md added, planning and requirements clarified.
+- **2025-06-15:** Implemented repo list editing UI and config updates.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A text-based user interface (TUI) Python app for managing GitHub branches and pu
 - List, delete, or select branches
 - Create, merge, and delete branches via PR in one step
 - Interactive branch actions widget for deleting or merging via PR
-- Update the list of managed repositories
+- Edit the list of managed repositories within the TUI
 
 ## Requirements
 - Python 3.8+
@@ -25,4 +25,4 @@ python main.py
 ```
 
 ## Configuration
-Edit `config.json` to add/remove repositories.
+Use the **Edit Repositories** view or modify `config.json` manually.


### PR DESCRIPTION
## Summary
- add `RepoEditor` widget for adding/removing repositories
- allow jumping to edit view from `RepoSelector`
- persist repo list updates and reload without restarting
- document edit view and mark task complete in progress tracker
- test editing repositories

## Testing
- `pytest -q`
- manual run of `PYTHONPATH=src python -m gh_pr_manager.main` (brief launch)

------
https://chatgpt.com/codex/tasks/task_b_684d8e65620c8330904f7d5b7c84cc30