### PR TITLE
[gh-pr-manager] add tests for config and branch flows

### DIFF
--- a/tests/test_app_pr_flow.py
+++ b/tests/test_app_pr_flow.py
@@ -1,0 +1,92 @@
+from gh_pr_manager import main
+import json
+import subprocess
+
+import pytest
+
+from gh_pr_manager.main import PRManagerApp
+
+
+def _completed(cmd: list[str], returncode: int = 0, stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
+
+
+@pytest.mark.asyncio
+async def test_pr_flow_success(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "branch", "feature"], cwd=repo, check=True, capture_output=True)
+
+    conf = tmp_path / "config.json"
+    conf.write_text(json.dumps({"repositories": [str(repo)]}))
+    monkeypatch.setattr(main, "CONFIG_PATH", conf)
+    monkeypatch.setattr(PRManagerApp, "CONFIG_PATH", conf, raising=False)
+
+    def fake_run(cmd, cwd=None, capture_output=True, text=True):
+        if cmd[:4] == ["git", "-C", str(repo), "branch"] and "--format=%(refname:short)" in cmd:
+            return _completed(cmd, stdout="main\nfeature\n")
+        if cmd[:3] == ["gh", "pr", "create"]:
+            return _completed(cmd)
+        if cmd[:3] == ["gh", "pr", "merge"]:
+            return _completed(cmd)
+        if cmd[:4] == ["git", "-C", str(repo), "branch"] and "-D" in cmd:
+            return _completed(cmd)
+        return _completed(cmd)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    app = PRManagerApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        pilot.app.query_one("#repo_select").value = str(repo)
+        await pilot.click("#continue")
+        await pilot.click("#confirm")
+        await pilot.pause()
+        pilot.app.query_one("#branch_select").value = "feature"
+        await pilot.click("#pr_flow")
+        await pilot.pause()
+        msg = pilot.app.query_one("#branch_list #action_msg").renderable
+
+    assert "PR merged and feature deleted" in msg
+
+
+@pytest.mark.asyncio
+async def test_pr_flow_create_error(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "branch", "feature"], cwd=repo, check=True, capture_output=True)
+
+    conf = tmp_path / "config.json"
+    conf.write_text(json.dumps({"repositories": [str(repo)]}))
+    monkeypatch.setattr(main, "CONFIG_PATH", conf)
+    monkeypatch.setattr(PRManagerApp, "CONFIG_PATH", conf, raising=False)
+
+    def fake_run(cmd, cwd=None, capture_output=True, text=True):
+        if cmd[:4] == ["git", "-C", str(repo), "branch"] and "--format=%(refname:short)" in cmd:
+            return _completed(cmd, stdout="main\nfeature\n")
+        if cmd[:3] == ["gh", "pr", "create"]:
+            return _completed(cmd, 1, stderr="create fail")
+        if cmd[:4] == ["git", "-C", str(repo), "branch"] and "-D" in cmd:
+            return _completed(cmd)
+        return _completed(cmd)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    app = PRManagerApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        pilot.app.query_one("#repo_select").value = str(repo)
+        await pilot.click("#continue")
+        await pilot.click("#confirm")
+        await pilot.pause()
+        pilot.app.query_one("#branch_select").value = "feature"
+        await pilot.click("#pr_flow")
+        await pilot.pause()
+        msg = pilot.app.query_one("#branch_list #action_msg").renderable
+
+    assert "Create failed: create fail" in msg
+

--- a/tests/test_config_and_branch.py
+++ b/tests/test_config_and_branch.py
@@ -1,0 +1,83 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from textual.app import App
+
+from gh_pr_manager import main
+from gh_pr_manager.main import BranchActions
+
+
+class _BranchApp(App):
+    def __init__(self, repo: str, branch: str, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.repo = repo
+        self.branch = branch
+
+    def compose(self):
+        yield BranchActions(self.repo, lambda: self.branch, lambda: None)
+
+
+def _completed(cmd: list[str], returncode: int = 0, stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
+
+
+def test_load_config_filters_invalid_repos(tmp_path, monkeypatch):
+    valid = tmp_path / "valid"
+    valid.mkdir()
+    invalid = tmp_path / "missing"
+    conf = tmp_path / "config.json"
+    conf.write_text(json.dumps({"repositories": [str(valid), str(invalid)]}))
+    monkeypatch.setattr(main, "CONFIG_PATH", conf)
+
+    app = main.PRManagerApp()
+    app.load_config()
+    assert app.repositories == [str(valid)]
+    assert app.invalid_repos == [str(invalid)]
+
+
+@pytest.mark.asyncio
+async def test_branch_actions_delete_branch(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    calls = []
+
+    def fake_run(cmd, cwd=None, capture_output=True, text=True):
+        calls.append(cmd)
+        if cmd[:4] == ["git", "-C", str(repo), "branch"] and "-D" in cmd:
+            return _completed(cmd)
+        return _completed(cmd)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    app = _BranchApp(str(repo), "feature")
+    async with app.run_test() as pilot:
+        await pilot.click("#delete_branch")
+        await pilot.pause()
+        msg = pilot.app.query_one("#action_msg").renderable
+
+    assert ["git", "-C", str(repo), "branch", "-D", "feature"] in calls
+    assert "Deleted feature" in msg
+
+
+@pytest.mark.asyncio
+async def test_branch_actions_pr_flow_create_fail(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def fake_run(cmd, cwd=None, capture_output=True, text=True):
+        if cmd[:3] == ["gh", "pr", "create"]:
+            return _completed(cmd, 1, stderr="create fail")
+        return _completed(cmd)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    app = _BranchApp(str(repo), "feature")
+    async with app.run_test() as pilot:
+        await pilot.click("#pr_flow")
+        await pilot.pause()
+        msg = pilot.app.query_one("#action_msg").renderable
+
+    assert "Create failed: create fail" in msg


### PR DESCRIPTION
## Summary
- test config loader and branch action helpers
- add integration tests for PR workflow success and gh failure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d913b3eec8330a091110e198a28f8