### PR TITLE
[gh-pr-manager] Stage 1 config refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@
 A text-based user interface (TUI) Python app for managing GitHub branches and pull requests using the `gh` CLI.
 
 ## Features
-- Select a repository from a pre-configured list
+ - Store the last selected repository for quick access
 - List, delete, or select branches
 - Create, merge, and delete branches via PR in one step
 - Interactive branch actions widget for deleting or merging via PR
-- Edit the list of managed repositories within the TUI
 
 ## Requirements
 - Python 3.8+

--- a/config.json
+++ b/config.json
@@ -1,6 +1,3 @@
 {
-    "repositories": [
-        "/path/to/your/repo1",
-        "/path/to/your/repo2"
-    ]
+    "selected_repository": ""
 }

--- a/src/config.json
+++ b/src/config.json
@@ -1,3 +1,3 @@
 {
-    "repositories": []
+    "selected_repository": ""
 }

--- a/src/gh_pr_manager/utils.py
+++ b/src/gh_pr_manager/utils.py
@@ -1,6 +1,6 @@
 import subprocess
 from pathlib import Path
-from typing import List, Tuple
+from typing import List
 
 
 def run_cmd(cmd: List[str], cwd: str | Path | None = None) -> tuple[bool, str]:
@@ -23,13 +23,4 @@ def run_cmd(cmd: List[str], cwd: str | Path | None = None) -> tuple[bool, str]:
     return True, result.stdout
 
 
-def filter_valid_repos(repos: List[str]) -> Tuple[List[str], List[str]]:
-    """Separate valid and invalid repository paths."""
-    valid: List[str] = []
-    invalid: List[str] = []
-    for repo in repos:
-        if Path(repo).is_dir():
-            valid.append(repo)
-        else:
-            invalid.append(repo)
-    return valid, invalid
+

--- a/tests/test_app_pr_flow.py
+++ b/tests/test_app_pr_flow.py
@@ -20,7 +20,7 @@ async def test_pr_flow_success(tmp_path, monkeypatch):
     subprocess.run(["git", "branch", "feature"], cwd=repo, check=True, capture_output=True)
 
     conf = tmp_path / "config.json"
-    conf.write_text(json.dumps({"repositories": [str(repo)]}))
+    conf.write_text(json.dumps({"selected_repository": str(repo)}))
     monkeypatch.setattr(main, "CONFIG_PATH", conf)
     monkeypatch.setattr(PRManagerApp, "CONFIG_PATH", conf, raising=False)
 
@@ -61,7 +61,7 @@ async def test_pr_flow_create_error(tmp_path, monkeypatch):
     subprocess.run(["git", "branch", "feature"], cwd=repo, check=True, capture_output=True)
 
     conf = tmp_path / "config.json"
-    conf.write_text(json.dumps({"repositories": [str(repo)]}))
+    conf.write_text(json.dumps({"selected_repository": str(repo)}))
     monkeypatch.setattr(main, "CONFIG_PATH", conf)
     monkeypatch.setattr(PRManagerApp, "CONFIG_PATH", conf, raising=False)
 

--- a/tests/test_app_smoke.py
+++ b/tests/test_app_smoke.py
@@ -26,7 +26,7 @@ async def test_select_repo_shows_branches(tmp_path, monkeypatch):
     subprocess.run(["git", "branch", "feature"], cwd=repo, check=True, capture_output=True)
 
     conf = tmp_path / "config.json"
-    conf.write_text(json.dumps({"repositories": [str(repo)]}))
+    conf.write_text(json.dumps({"selected_repository": str(repo)}))
     monkeypatch.setattr(main, "CONFIG_PATH", conf)
 
     app = PRManagerApp()
@@ -54,7 +54,7 @@ async def test_delete_branch_runs_git(tmp_path, monkeypatch):
     subprocess.run(["git", "branch", "feature"], cwd=repo, check=True, capture_output=True)
 
     conf = tmp_path / "config.json"
-    conf.write_text(json.dumps({"repositories": [str(repo)]}))
+    conf.write_text(json.dumps({"selected_repository": str(repo)}))
     monkeypatch.setattr(main, "CONFIG_PATH", conf)
 
     calls = []
@@ -82,6 +82,7 @@ async def test_delete_branch_runs_git(tmp_path, monkeypatch):
     assert ["git", "-C", str(repo), "branch", "-D", "feature"] in calls
 
 
+@pytest.mark.skip("repo editing removed")
 @pytest.mark.asyncio
 async def test_edit_repositories_updates_config(tmp_path, monkeypatch):
     repo1 = tmp_path / "r1"
@@ -90,7 +91,7 @@ async def test_edit_repositories_updates_config(tmp_path, monkeypatch):
     repo2.mkdir()
 
     conf = tmp_path / "config.json"
-    conf.write_text(json.dumps({"repositories": [str(repo1), str(repo2)]}))
+    conf.write_text(json.dumps({"selected_repository": str(repo1)}))
     monkeypatch.setattr(main, "CONFIG_PATH", conf)
 
     new_repo = tmp_path / "r3"
@@ -110,10 +111,11 @@ async def test_edit_repositories_updates_config(tmp_path, monkeypatch):
         options = [opt[1] for opt in select._options[1:]]
 
     data = json.loads(conf.read_text())
-    assert data["repositories"] == [str(repo2), str(new_repo)]
-    assert options == [str(repo2), str(new_repo)]
+    assert data["selected_repository"] == str(new_repo)
+    assert options == []
 
 
+@pytest.mark.skip("repo validation removed")
 @pytest.mark.asyncio
 async def test_invalid_repo_shows_message(tmp_path, monkeypatch):
     repo = tmp_path / "valid"
@@ -121,7 +123,7 @@ async def test_invalid_repo_shows_message(tmp_path, monkeypatch):
     bad_repo = tmp_path / "missing"
 
     conf = tmp_path / "config.json"
-    conf.write_text(json.dumps({"repositories": [str(repo), str(bad_repo)]}))
+    conf.write_text(json.dumps({"selected_repository": str(repo)}))
     monkeypatch.setattr(main, "CONFIG_PATH", conf)
 
     app = PRManagerApp()

--- a/tests/test_config_and_branch.py
+++ b/tests/test_config_and_branch.py
@@ -23,18 +23,14 @@ def _completed(cmd: list[str], returncode: int = 0, stdout: str = "", stderr: st
     return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
 
 
-def test_load_config_filters_invalid_repos(tmp_path, monkeypatch):
-    valid = tmp_path / "valid"
-    valid.mkdir()
-    invalid = tmp_path / "missing"
+def test_load_config_reads_selected_repo(tmp_path, monkeypatch):
     conf = tmp_path / "config.json"
-    conf.write_text(json.dumps({"repositories": [str(valid), str(invalid)]}))
+    conf.write_text(json.dumps({"selected_repository": "example/repo"}))
     monkeypatch.setattr(main, "CONFIG_PATH", conf)
 
     app = main.PRManagerApp()
     app.load_config()
-    assert app.repositories == [str(valid)]
-    assert app.invalid_repos == [str(invalid)]
+    assert app.selected_repo == "example/repo"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- drop local repo list support
- simplify repo selector and app logic
- update configuration files to use `selected_repository`
- remove obsolete utilities and widgets
- adjust tests and docs for the new structure

## Testing
- `pytest -q` *(fails: No nodes match '#repo_select' on PRManagerApp ...)*

------
https://chatgpt.com/codex/tasks/task_b_684dbbf380cc8330a28c20f9c00c3db3