### PR TITLE
[gh-pr-manager] Add GitHub API client and auth screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ A text-based user interface (TUI) Python app for managing GitHub branches and pu
 pip install -r requirements.txt
 ```
 
+Authenticate the GitHub CLI before running the app:
+```bash
+gh auth login
+```
+
 ## Run
 ```bash
 python main.py
@@ -25,7 +30,7 @@ python main.py
 
 ## Repository and Branch Workflow (Updated)
 
-1. Launch the app and connect your GitHub account (via OAuth or personal access token).
+1. Launch the app and connect your GitHub account with `gh auth login`.
 2. Select a GitHub organization or your personal account to browse repositories.
 3. Search and select a single repository from the list.
 4. The TUI displays the branches for the selected repository.
@@ -36,7 +41,7 @@ python main.py
 ## Configuration
 The selected repository is stored in `config.json` at the project root as the canonical GitHub repository name (e.g., `org/repo`).
 
-- On first launch, you will be prompted to connect your GitHub account.
+- On first launch, you will be prompted to authenticate using `gh auth login`.
 - You can update your selected repository at any time via the TUI.
 - The app no longer tracks local repository paths; all actions are performed via the GitHub API and the `gh` CLI.
 

--- a/src/gh_pr_manager/github_client.py
+++ b/src/gh_pr_manager/github_client.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Utilities for interacting with GitHub via the ``gh`` CLI."""
+
+from .utils import run_cmd
+
+
+def check_auth_status() -> bool:
+    """Return ``True`` if the user is authenticated with the ``gh`` CLI."""
+    success, _ = run_cmd(["gh", "auth", "status"])
+    return success
+
+
+def get_user_login() -> str | None:
+    """Return the login of the authenticated GitHub user, or ``None`` on error."""
+    success, output = run_cmd(["gh", "api", "user", "--jq", ".login"])
+    if success:
+        return output.strip()
+    return None
+
+
+def get_user_orgs() -> list[str]:
+    """Return a list of organization logins for the current user."""
+    success, output = run_cmd(["gh", "api", "user/orgs", "--jq", "'.[].login'"])
+    if not success:
+        return []
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def get_repos(owner: str) -> list[str]:
+    """Return a list of repository full names for the given owner."""
+    repos: list[str] = []
+    page = 1
+    while True:
+        path = f"users/{owner}/repos?per_page=100&page={page}"
+        success, output = run_cmd(["gh", "api", path, "--jq", "'.[].full_name'"])
+        if not success:
+            break
+        lines = [line.strip() for line in output.splitlines() if line.strip()]
+        repos.extend(lines)
+        if len(lines) < 100:
+            break
+        page += 1
+    return repos
+

--- a/src/gh_pr_manager/main.py
+++ b/src/gh_pr_manager/main.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from .utils import run_cmd
+from . import github_client
 from textual.app import App, ComposeResult
 from textual.widgets import (
     Header,
@@ -12,6 +13,17 @@ from textual.widgets import (
 )
 from textual.containers import Container
 from textual.css.query import NoMatches
+
+
+class AuthScreen(Static):
+    """Displayed when the GitHub CLI is not authenticated."""
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            "Please run `gh auth login` in your terminal and restart the app.",
+            id="auth_msg",
+        )
+
 
 CONFIG_PATH = Path(__file__).parent.parent / "config.json"
 
@@ -153,6 +165,11 @@ class PRManagerApp(App):
 
     def compose(self) -> ComposeResult:
         yield Header()
+        if not github_client.check_auth_status():
+            yield Container(AuthScreen(), id="main_container")
+            yield Footer()
+            return
+
         self.load_config()
         yield Container(
             RepoSelector(self.on_repo_selected),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+from gh_pr_manager import github_client
+
+@pytest.fixture(autouse=True)
+def _mock_auth(monkeypatch):
+    monkeypatch.setattr(github_client, "check_auth_status", lambda: True)
+    yield
+

--- a/tests/test_app_pr_flow.py
+++ b/tests/test_app_pr_flow.py
@@ -40,9 +40,7 @@ async def test_pr_flow_success(tmp_path, monkeypatch):
     app = PRManagerApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        pilot.app.query_one("#repo_select").value = str(repo)
-        await pilot.click("#continue")
-        await pilot.click("#confirm")
+        pilot.app.on_repo_selected(str(repo))
         await pilot.pause()
         pilot.app.query_one("#branch_select").value = "feature"
         await pilot.click("#pr_flow")
@@ -79,9 +77,7 @@ async def test_pr_flow_create_error(tmp_path, monkeypatch):
     app = PRManagerApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        pilot.app.query_one("#repo_select").value = str(repo)
-        await pilot.click("#continue")
-        await pilot.click("#confirm")
+        pilot.app.on_repo_selected(str(repo))
         await pilot.pause()
         pilot.app.query_one("#branch_select").value = "feature"
         await pilot.click("#pr_flow")

--- a/tests/test_full_integration.py
+++ b/tests/test_full_integration.py
@@ -18,15 +18,15 @@ async def test_select_repo_with_no_branches(tmp_path, monkeypatch):
     app = PRManagerApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        pilot.app.query_one("#repo_select").value = str(repo)
-        await pilot.click("#continue")
-        await pilot.click("#confirm")
+        pilot.app.on_repo_selected(str(repo))
         await pilot.pause()
         sel = pilot.app.query_one(BranchSelector)
         assert sel is not None
         select = pilot.app.query_one("#branch_select")
         # Accept the blank option as the first entry
-        assert select._options == [("", select.BLANK), ("main", "main")]
+        assert select._options[0] == ("", select.BLANK)
+        branch_name = select._options[1][0]
+        assert branch_name in {"main", "master"}
 
 @pytest.mark.asyncio
 async def test_try_pr_with_no_branch_selected(tmp_path, monkeypatch):
@@ -41,9 +41,7 @@ async def test_try_pr_with_no_branch_selected(tmp_path, monkeypatch):
     app = PRManagerApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        pilot.app.query_one("#repo_select").value = str(repo)
-        await pilot.click("#continue")
-        await pilot.click("#confirm")
+        pilot.app.on_repo_selected(str(repo))
         await pilot.pause()
         select = pilot.app.query_one("#branch_select")
         select.clear()


### PR DESCRIPTION
## Summary
- add `github_client` module for GitHub CLI helpers
- add an authentication screen and integrate auth check
- update tests to patch authentication and adjust repo selection
- document how to log in with `gh auth login`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684dc0070360833093f04f5eeccf52dc