### PR TITLE
[gh-pr-manager] implement repo selection ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 A text-based user interface (TUI) Python app for managing GitHub branches and pull requests using the `gh` CLI.
 
 ## Features
- - Store the last selected repository for quick access
+- Store the last selected repository for quick access
+- Choose a repository from your GitHub organizations or account
 - List, delete, or select branches
 - Create, merge, and delete branches via PR in one step
 - Interactive branch actions widget for deleting or merging via PR

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,5 +4,8 @@ from gh_pr_manager import github_client
 @pytest.fixture(autouse=True)
 def _mock_auth(monkeypatch):
     monkeypatch.setattr(github_client, "check_auth_status", lambda: True)
+    monkeypatch.setattr(github_client, "get_user_login", lambda: "me")
+    monkeypatch.setattr(github_client, "get_user_orgs", lambda: ["org"])
+    monkeypatch.setattr(github_client, "get_repos", lambda owner: [f"{owner}/repo"])
     yield
 

--- a/tests/test_app_pr_flow.py
+++ b/tests/test_app_pr_flow.py
@@ -40,6 +40,8 @@ async def test_pr_flow_success(tmp_path, monkeypatch):
     app = PRManagerApp()
     async with app.run_test() as pilot:
         await pilot.pause()
+        pilot.app.on_owner_selected("org")
+        await pilot.pause()
         pilot.app.on_repo_selected(str(repo))
         await pilot.pause()
         pilot.app.query_one("#branch_select").value = "feature"
@@ -76,6 +78,8 @@ async def test_pr_flow_create_error(tmp_path, monkeypatch):
 
     app = PRManagerApp()
     async with app.run_test() as pilot:
+        await pilot.pause()
+        pilot.app.on_owner_selected("org")
         await pilot.pause()
         pilot.app.on_repo_selected(str(repo))
         await pilot.pause()

--- a/tests/test_app_smoke.py
+++ b/tests/test_app_smoke.py
@@ -29,20 +29,16 @@ async def test_auth_screen_shown_when_not_logged_in(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_select_repo_shows_branches(tmp_path, monkeypatch):
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
-    subprocess.run(["git", "commit", "--allow-empty", "-m", "init"], cwd=repo, check=True, capture_output=True)
-    subprocess.run(["git", "branch", "feature"], cwd=repo, check=True, capture_output=True)
-
     conf = tmp_path / "config.json"
-    conf.write_text(json.dumps({"selected_repository": str(repo)}))
+    conf.write_text(json.dumps({"selected_repository": ""}))
     monkeypatch.setattr(main, "CONFIG_PATH", conf)
 
     app = PRManagerApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        pilot.app.on_repo_selected(str(repo))
+        pilot.app.on_owner_selected("org")
+        await pilot.pause()
+        pilot.app.on_repo_selected("org/repo")
         await pilot.pause()
         assert pilot.app.query_one(BranchSelector)
 
@@ -78,6 +74,8 @@ async def test_delete_branch_runs_git(tmp_path, monkeypatch):
 
     app = PRManagerApp()
     async with app.run_test() as pilot:
+        await pilot.pause()
+        pilot.app.on_owner_selected("org")
         await pilot.pause()
         pilot.app.on_repo_selected(str(repo))
         await pilot.pause()

--- a/tests/test_org_repo_flow.py
+++ b/tests/test_org_repo_flow.py
@@ -1,0 +1,28 @@
+import json
+import pytest
+
+from gh_pr_manager import main
+from gh_pr_manager.main import PRManagerApp, OrgSelector, RepoSelectionWidget
+from gh_pr_manager import github_client
+
+
+@pytest.mark.asyncio
+async def test_org_and_repo_selection_saves_config(tmp_path, monkeypatch):
+    conf = tmp_path / "config.json"
+    monkeypatch.setattr(main, "CONFIG_PATH", conf)
+    monkeypatch.setattr(github_client, "get_user_login", lambda: "me")
+    monkeypatch.setattr(github_client, "get_user_orgs", lambda: ["org"])
+    monkeypatch.setattr(github_client, "get_repos", lambda owner: [f"{owner}/r1", f"{owner}/r2"])    
+
+    app = PRManagerApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert pilot.app.query_one(OrgSelector)
+        pilot.app.on_owner_selected("org")
+        await pilot.pause()
+        assert pilot.app.query_one(RepoSelectionWidget)
+        pilot.app.on_repo_selected("org/r1")
+        await pilot.pause()
+
+    data = json.loads(conf.read_text())
+    assert data["selected_repository"] == "org/r1"


### PR DESCRIPTION
## Summary
- add OrgSelector and RepoSelectionWidget for GitHub-based repository selection
- update main app flow to use the new widgets and save selected repo
- update documentation with new feature
- adapt existing tests and add new test coverage for org/repo selection

## Testing
- `pytest -q`
- Manual attempt to start the TUI (`python -m gh_pr_manager`, killed after launch)

------
https://chatgpt.com/codex/tasks/task_b_684dc18b0f248330a4a1a807e2321874